### PR TITLE
Peft tests

### DIFF
--- a/bitsandbytes/functional.py
+++ b/bitsandbytes/functional.py
@@ -1627,7 +1627,7 @@ def gemv_4bit(
     ldb = ct.c_int32(ldb)
     ldc = ct.c_int32(ldc)
 
-    if B.dtype == torch.float32:
+    if B.dtype in [torch.uint8, torch.bfloat16, torch.float32]:
         if A.dtype == torch.float16:
             lib.cgemm_4bit_inference_naive_fp16(m, n, k, get_ptr(A), get_ptr(B), get_ptr(absmax), get_ptr(state.code), get_ptr(out), lda, ldb, ldc, ct.c_int32(state.blocksize))
         elif A.dtype == torch.bfloat16:

--- a/bitsandbytes/nn/modules.py
+++ b/bitsandbytes/nn/modules.py
@@ -151,7 +151,8 @@ class Params4bit(torch.nn.Parameter):
             compress_statistics: bool = True,
             quant_type: str = 'fp4',
             quant_storage: torch.dtype = torch.uint8,
-            module: Optional["Linear4bit"] = None
+            module: Optional["Linear4bit"] = None,
+            bnb_quantized: bool = False
     ) -> "Params4bit":
         if data is None:
             data = torch.empty(0)
@@ -162,7 +163,7 @@ class Params4bit(torch.nn.Parameter):
         self.quant_type = quant_type
         self.quant_state = quant_state
         self.quant_storage = quant_storage
-        self.bnb_quantized = False
+        self.bnb_quantized = bnb_quantized
         self.data = data
         self.module = module
         return self
@@ -224,7 +225,7 @@ class Linear4bit(nn.Linear):
 
     def __init__(self, input_features, output_features, bias=True, compute_dtype=None, compress_statistics=True, quant_type='fp4', quant_storage=torch.uint8, device=None):
         super().__init__(input_features, output_features, bias, device)
-        self.weight = Params4bit(self.weight.data, requires_grad=False, compress_statistics=compress_statistics, quant_type=quant_type, quant_storage=quant_storage, module=self)
+        self.weight = Params4bit(self.weight.data, requires_grad=False, compress_statistics=compress_statistics, quant_type=quant_type, quant_storage=quant_storage, module=self, bnb_quantized=False)
         # self.persistent_buffers = []  # TODO consider as way to save quant state
         self.compute_dtype = compute_dtype
         self.compute_type_is_set = False

--- a/bitsandbytes/nn/modules.py
+++ b/bitsandbytes/nn/modules.py
@@ -225,7 +225,7 @@ class Linear4bit(nn.Linear):
 
     def __init__(self, input_features, output_features, bias=True, compute_dtype=None, compress_statistics=True, quant_type='fp4', quant_storage=torch.uint8, device=None):
         super().__init__(input_features, output_features, bias, device)
-        self.weight = Params4bit(self.weight.data, requires_grad=False, compress_statistics=compress_statistics, quant_type=quant_type, quant_storage=quant_storage, module=self, bnb_quantized=False)
+        self.weight = Params4bit(self.weight.data, requires_grad=False, compress_statistics=compress_statistics, quant_type=quant_type, quant_storage=quant_storage, module=self)
         # self.persistent_buffers = []  # TODO consider as way to save quant state
         self.compute_dtype = compute_dtype
         self.compute_type_is_set = False


### PR DESCRIPTION
`B.dtype` which is the data type of the packed 4bit values can now have different dtypes other than uint8, so the check should consider it.

`bnb_quantized` is missing when `Params4bit.__new__()` used for setting a param, so added it as an arg.

```python
module._parameters[name] = param_cls(module._parameters[name].to(device), **kwargs)
```

These fix multiple tests in `peft/tests/test_common_gpu.py`